### PR TITLE
ci: use local ca in system tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -146,6 +146,7 @@ jobs:
           touch .env
           echo 'C8Y_BASEURL="${{ secrets.C8Y_BASEURL }}"' >> .env
           echo 'C8Y_USER="${{ secrets.C8Y_USER }}"' >> .env
+          echo 'C8Y_TENANT="${{ secrets.C8Y_TENANT }}"' >> .env
           echo 'C8Y_PASSWORD="${{ secrets.C8Y_PASSWORD }}"' >> .env
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -148,6 +148,8 @@ jobs:
           echo 'C8Y_USER="${{ secrets.C8Y_USER }}"' >> .env
           echo 'C8Y_TENANT="${{ secrets.C8Y_TENANT }}"' >> .env
           echo 'C8Y_PASSWORD="${{ secrets.C8Y_PASSWORD }}"' >> .env
+          echo 'CA_KEY="${{ secrets.CA_KEY || '' }}"' >> .env
+          echo 'CA_PUB="${{ secrets.CA_PUB || '' }}"' >> .env
 
       - uses: actions/setup-python@v5
         with:

--- a/docs/src/operate/security/device-certificate.md
+++ b/docs/src/operate/security/device-certificate.md
@@ -36,12 +36,12 @@ Note that *only* the MQTT broker should be able to read or write the private key
 Then thin-edge must be told where the certificate is stored.
 Note that the device certificate file must contain not only the device certificate itself
 but also the signing certificate
-(so the cloud endpoint can check the chain, starting from a trusted root upto the device certificate).
+(so the cloud endpoint can check the chain, starting from the device certificate up to the trusted root).
 
 ```sh
-# Create a new cert chain, which contains both the signing and device public cert
-cat signing-cert.pem > demo-device-007.chain.pem
-cat demo-device-007.pem >> demo-device-007.chain.pem
+# Create a new cert chain, which contains both the device public cert and the signing (in that order)
+cat demo-device-007.pem > demo-device-007.chain.pem
+cat signing-cert.pem >> demo-device-007.chain.pem
 
 # Configure the cert chain file as the main cert to be used by thin-edge.io
 tedge config set device.cert_path /etc/mosquitto/certs/demo-device-007.chain.pem

--- a/tests/RobotFramework/requirements/requirements.txt
+++ b/tests/RobotFramework/requirements/requirements.txt
@@ -2,7 +2,7 @@ dateparser~=1.2.0
 paho-mqtt~=1.6.1
 python-dotenv~=1.0.0
 robotframework~=6.1.1
-robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.27.0
+robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.30.0
 robotframework-debuglibrary~=2.3.0
 robotframework-jsonlibrary~=0.5
 robotframework-pabot~=2.16.0

--- a/tests/RobotFramework/tests/cumulocity/telemetry/child_device_telemetry.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/child_device_telemetry.robot
@@ -244,36 +244,39 @@ Nested child devices support sending event
  
 # Nested child device services 
 Nested child device service support sending simple measurements
-    ${nested_child}=    Get Random Name    
+    ${nested_child}=    Get Random Name
+    ${service_name}=    Get Random Name
     Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}/service/nested_ms_service' '{"@type":"service","@parent":"device/${nested_child}//","@id":"nested_ms_service"}'
-    Execute Command    tedge mqtt pub te/device/${nested_child}/service/nested_ms_service/m/m_type '{ "temperature": 30.1 }'
+    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}/service/${service_name}' '{"@type":"service","@parent":"device/${nested_child}//","@id":"${service_name}"}'
+    Execute Command    tedge mqtt pub te/device/${nested_child}/service/${service_name}/m/m_type '{ "temperature": 30.1 }'
     Cumulocity.Device Should Exist    ${nested_child}
-    Cumulocity.Should Have Services    name=nested_ms_service    min_count=1    max_count=1  
-    Cumulocity.Device Should Exist   nested_ms_service
+    Cumulocity.Should Have Services    name=${service_name}    min_count=1    max_count=1  
+    Cumulocity.Device Should Exist   ${service_name}
     ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1
     Should Be Equal    ${measurements[0]["type"]}    m_type
     Should Be Equal As Numbers    ${measurements[0]["temperature"]["temperature"]["value"]}    30.1
     Log    ${measurements}
 
 Nested child device service support sending events
-    ${nested_child}=    Get Random Name    
+    ${nested_child}=    Get Random Name
+    ${service_name}=    Get Random Name
     Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}/service/nested_event_service' '{"@type":"service","@parent":"device/${nested_child}//","@id":"nested_event_service"}'
-    Execute Command    tedge mqtt pub te/device/${nested_child}/service/nested_event_service/e/e_type '{ "text": "nested device service started" }'
+    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}/service/${service_name}' '{"@type":"service","@parent":"device/${nested_child}//","@id":"${service_name}"}'
+    Execute Command    tedge mqtt pub te/device/${nested_child}/service/${service_name}/e/e_type '{ "text": "nested device service started" }'
     Cumulocity.Device Should Exist    ${nested_child}    
-    Cumulocity.Should Have Services    name=nested_event_service    min_count=1    max_count=1  
-    Cumulocity.Device Should Exist   nested_event_service
+    Cumulocity.Should Have Services    name=${service_name}    min_count=1    max_count=1  
+    Cumulocity.Device Should Exist   ${service_name}
     Device Should Have Event/s    expected_text=nested device service started    type=e_type    minimum=1    maximum=1
    
 Nested child device service support sending alarm
     ${nested_child}=    Get Random Name
+    ${service_name}=    Get Random Name
     Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}/service/nested_alarm_service' '{"@type":"service","@parent":"device/${nested_child}//","@id":"nested_alarm_service"}'
-    Execute Command    tedge mqtt pub te/device/${nested_child}/service/nested_alarm_service/a/test_alarm '{ "severity":"critical","text":"temperature alarm" }'
+    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}/service/${service_name}' '{"@type":"service","@parent":"device/${nested_child}//","@id":"${service_name}"}'
+    Execute Command    tedge mqtt pub te/device/${nested_child}/service/${service_name}/a/test_alarm '{ "severity":"critical","text":"temperature alarm" }'
     Cumulocity.Device Should Exist    ${nested_child}    
-    Cumulocity.Should Have Services    name=nested_alarm_service    min_count=1    max_count=1  
-    Cumulocity.Device Should Exist   nested_alarm_service
+    Cumulocity.Should Have Services    name=${service_name}    min_count=1    max_count=1  
+    Cumulocity.Device Should Exist   ${service_name}
     ${alarm}=    Device Should Have Alarm/s    type=test_alarm    expected_text=temperature alarm   severity=CRITICAL    minimum=1    maximum=1  
     Log    ${alarm}
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Inject local ca via environment variables so that each container can create their own leaf certificate. This avoid maintaining multiple trusted certificates in the cloud

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

